### PR TITLE
Add Test Case for Environment, Namespace tests, Fixed HTTP timeout issue

### DIFF
--- a/src/Knack/ZeroBounce/API/ZeroBounceAPI.php
+++ b/src/Knack/ZeroBounce/API/ZeroBounceAPI.php
@@ -26,7 +26,7 @@ class ZeroBounceAPI {
      * @return mixed
      */
     private function apiCall( $method, array $params ): array {
-        if(empty($this->key)) {
+        if ( empty( $this->key ) ) {
             throw new EmptyAPIKeyException( 'Invalid ZeroBounce API key' );
         }
 
@@ -34,9 +34,9 @@ class ZeroBounceAPI {
         $paramsURI         = http_build_query( $params );
         $url               = "{$this->baseUrl}{$method}?{$paramsURI}";
 
-        $response = $this->client->get( $url ,[
-            'timeout' => Environment::get( 'ZEROBOUNCE_HTTP_TIMEOUT' ) || 3
-        ]);
+        $response = $this->client->get( $url, [
+            'timeout' => Environment::get( 'ZEROBOUNCE_HTTP_TIMEOUT' ) ? (float) Environment::get( 'ZEROBOUNCE_HTTP_TIMEOUT' ) : 3.0
+        ] );
 
         if ( $response->getStatusCode() === 200 ) {
             return json_decode( $response->getBody(), true );

--- a/tests/functional/API/ZeroBounceTest.php
+++ b/tests/functional/API/ZeroBounceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace Knack\ZeroBounce\Tests\Functional\API;
 
 use Dotenv\Dotenv;
 use Knack\ZeroBounce\API\ZeroBounce;

--- a/tests/functional/Utilities/EnvironmentTest.php
+++ b/tests/functional/Utilities/EnvironmentTest.php
@@ -1,0 +1,24 @@
+<?php namespace Knack\ZeroBounce\Tests\Functional\Utilities;
+
+use Dotenv\Dotenv;
+use Knack\ZeroBounce\Utilities\Environment;
+use PHPUnit\Framework\TestCase;
+
+final class EnvironmentTest extends TestCase {
+
+    /**
+     * Test set up.
+     */
+    public function setUp() {
+        parent::setUp();
+        $dotenv = new Dotenv( __DIR__ . '/../../../' );
+        $dotenv->load();
+    }
+
+    /**
+     * Test Environment Variable is fetched successfully.
+     */
+    public function testEnvironmentVariableFetch() {
+        $this->assertNotNull(Environment::get('ZEROBOUNCE_API_KEY'));
+    }
+}

--- a/tests/unit/Enum/GenderEnumTest.php
+++ b/tests/unit/Enum/GenderEnumTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Enums\GenderEnum;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Enum/StatusEnumTest.php
+++ b/tests/unit/Enum/StatusEnumTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Enums\StatusEnum;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Enum/SubStatusEnumTest.php
+++ b/tests/unit/Enum/SubStatusEnumTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Enums\SubStatusEnum;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
# Description

Please include a summary of the changes as well as the motivation/context for reviewers.

HTTP Timeouts on Guzzle requests were timing out. This is due to the following statement:

`Environment::get('ZEROBOUNCE_HTTP_TIMEOUT') || 3`

This is due to the fact that this returned `true` rather than `3`.

Additionally, the tests are now namespaced and there is now been a test case added for Environment.

# Issues

Please include the issues that this PR will affect or close.

- Closes #25 

# Checklist

Please ensure that all of the items are checked before your PR is merged.

- [x] I have performed a self-review of my own code (e.g. no typos, unnecessary comments, unused vars, etc)
- [x] I have added/updated tests that prove my fix is effective or that my feature works
