### PR TITLE
Allow Environment to return default values

### DIFF
--- a/src/Knack/ZeroBounce/Enums/GenderEnum.php
+++ b/src/Knack/ZeroBounce/Enums/GenderEnum.php
@@ -24,9 +24,9 @@ namespace Knack\ZeroBounce\Enums;
  */
 class GenderEnum
 {
-    const MALE = 'male';
+    public const MALE = 'male';
 
-    const FEMALE = 'female';
+    public const FEMALE = 'female';
 
     /**
      * Return enum from passed value
@@ -35,7 +35,7 @@ class GenderEnum
      *
      * @return string|null
      */
-    public static function from($value = '')
+    public static function from($value = ''): ?string
     {
         switch ($value) {
         case 'male':

--- a/src/Knack/ZeroBounce/Enums/StatusEnum.php
+++ b/src/Knack/ZeroBounce/Enums/StatusEnum.php
@@ -24,19 +24,19 @@ namespace Knack\ZeroBounce\Enums;
  */
 class StatusEnum
 {
-    const VALID = 'valid';
+    public const VALID = 'valid';
 
-    const INVALID = 'invalid';
+    public const INVALID = 'invalid';
 
-    const CATCH_ALL = 'catch-all';
+    public const CATCH_ALL = 'catch-all';
 
-    const UNKNOWN = 'unknown';
+    public const UNKNOWN = 'unknown';
 
-    const SPAMTRAP = 'spamtrap';
+    public const SPAMTRAP = 'spamtrap';
 
-    const ABUSE = 'abuse';
+    public const ABUSE = 'abuse';
 
-    const DO_NOT_MAIL = 'do_not_mail';
+    public const DO_NOT_MAIL = 'do_not_mail';
 
     /**
      * Return enum from passed value

--- a/src/Knack/ZeroBounce/Enums/SubStatusEnum.php
+++ b/src/Knack/ZeroBounce/Enums/SubStatusEnum.php
@@ -24,47 +24,47 @@ namespace Knack\ZeroBounce\Enums;
  */
 class SubStatusEnum
 {
-    const ANTISPAM_SYSTEM = 'antispam_system';
+    public const ANTISPAM_SYSTEM = 'antispam_system';
 
-    const GREYLISTED = 'greylisted';
+    public const GREYLISTED = 'greylisted';
 
-    const MAIL_SERVER_TEMPORARY_ERROR = 'mail_server_temporary_error';
+    public const MAIL_SERVER_TEMPORARY_ERROR = 'mail_server_temporary_error';
 
-    const FORCIBLE_DISCONNECT = 'forcible_disconnect';
+    public const FORCIBLE_DISCONNECT = 'forcible_disconnect';
 
-    const TIMEOUT_EXCEEDED = 'timeout_exceeded';
+    public const TIMEOUT_EXCEEDED = 'timeout_exceeded';
 
-    const FAILED_SMTP_CONNECTION = 'failed_smtp_connection';
+    public const FAILED_SMTP_CONNECTION = 'failed_smtp_connection';
 
-    const MAILBOX_QUOTA_EXCEEDED = 'mailbox_quota_exceeded';
+    public const MAILBOX_QUOTA_EXCEEDED = 'mailbox_quota_exceeded';
 
-    const EXCEPTION_OCCURRED = 'exception_occurred';
+    public const EXCEPTION_OCCURRED = 'exception_occurred';
 
-    const POSSIBLE_TRAPS = 'possible_traps';
+    public const POSSIBLE_TRAPS = 'possible_traps';
 
-    const ROLE_BASED = 'role_based';
+    public const ROLE_BASED = 'role_based';
 
-    const GLOBAL_SUPPRESSION = 'global_suppression';
+    public const GLOBAL_SUPPRESSION = 'global_suppression';
 
-    const MAILBOX_NOT_FOUND = 'mailbox_not_found';
+    public const MAILBOX_NOT_FOUND = 'mailbox_not_found';
 
-    const NO_DNS_ENTRIES = 'no_dns_entries';
+    public const NO_DNS_ENTRIES = 'no_dns_entries';
 
-    const FAILED_SYNTAX_CHECK = 'failed_syntax_check';
+    public const FAILED_SYNTAX_CHECK = 'failed_syntax_check';
 
-    const POSSIBLE_TYPO = 'possible_typo';
+    public const POSSIBLE_TYPO = 'possible_typo';
 
-    const UNROUTABLE_IP_ADDRESS = 'unroutable_ip_address';
+    public const UNROUTABLE_IP_ADDRESS = 'unroutable_ip_address';
 
-    const LEADING_PERIOD_REMOVED = 'leading_period_removed';
+    public const LEADING_PERIOD_REMOVED = 'leading_period_removed';
 
-    const DOES_NOT_ACCEPT_MAIL = 'does_not_accept_mail';
+    public const DOES_NOT_ACCEPT_MAIL = 'does_not_accept_mail';
 
-    const ROLE_BASED_CATCH_ALL = 'role_based_catch_all';
+    public const ROLE_BASED_CATCH_ALL = 'role_based_catch_all';
 
-    const DISPOSABLE = 'disposable';
+    public const DISPOSABLE = 'disposable';
 
-    const TOXIC = 'toxic';
+    public const TOXIC = 'toxic';
 
     /**
      * Return enum from passed value
@@ -73,7 +73,7 @@ class SubStatusEnum
      *
      * @return string|null
      */
-    public static function from($value = '')
+    public static function from($value = ''): ?string
     {
         switch ($value) {
         case 'antispam_system':

--- a/src/Knack/ZeroBounce/Exceptions/ResponseException.php
+++ b/src/Knack/ZeroBounce/Exceptions/ResponseException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * The Exception for if there is an error with the ZeroBounce API
+ * The Exception for if there is an error with the response from the ZeroBounce API
  *
  * PHP Version 7.0
  *

--- a/src/Knack/ZeroBounce/Exceptions/ZeroBounceException.php
+++ b/src/Knack/ZeroBounce/Exceptions/ZeroBounceException.php
@@ -1,11 +1,39 @@
 <?php
+
+/**
+ * The Exception for if there is an error with the ZeroBounce API
+ *
+ * PHP Version 7.0
+ *
+ * @category Exceptions
+ * @package  Knack\ZeroBounce\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Exceptions;
 
 use RuntimeException;
 use Throwable;
 
+/**
+ * Class ZeroBounceException
+ *
+ * @category Exceptions
+ * @package  Knack\ZeroBounce\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 class ZeroBounceException extends RuntimeException
 {
+    /**
+     * ZeroBounceException constructor.
+     *
+     * @param string         $message  the message
+     * @param int            $code     the code to throw
+     * @param Throwable|null $previous the previous thrown
+     */
     public function __construct($message = '', $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/src/Knack/ZeroBounce/Utilities/Environment.php
+++ b/src/Knack/ZeroBounce/Utilities/Environment.php
@@ -1,17 +1,67 @@
 <?php
+
+/**
+ * The getter for environment variables
+ *
+ * PHP Version 7.0
+ *
+ * @category Enums
+ * @package  Knack\ZeroBounce\Enums
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Utilities;
 
+/**
+ * Class Environment
+ *
+ * @category Enums
+ * @package  Knack\ZeroBounce\Utilities
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 class Environment
 {
     /**
      * Get an environment variable by key name
      *
-     * @param string $key the key of the variable to lookup
+     * @param string $key     the key of the variable to lookup
+     * @param mixed  $default the default value to return if the environment variable is not found
      *
      * @return array|false|string
      */
-    public static function get(string $key)
+    public static function get(string $key, $default = '')
     {
-        return getenv($key);
+        $environmentVariable = getenv($key);
+
+        if ($environmentVariable === false) {
+            return value($default);
+        }
+
+        switch (strtolower($environmentVariable)) {
+        case 'true':
+        case '(true)':
+            return true;
+        case 'false':
+        case '(false)':
+            return false;
+        case 'empty':
+        case '(empty)':
+            return '';
+        case 'null':
+        case '(null)':
+            return;
+        }
+
+        if (($valueLength = strlen($environmentVariable)) > 1
+            && strpos($environmentVariable, '"') === 0
+            && $environmentVariable[$valueLength - 1] === '"'
+        ) {
+            return substr($environmentVariable, 1, - 1);
+        }
+
+        return $environmentVariable;
     }
 }

--- a/tests/functional/API/ZeroBounceTest.php
+++ b/tests/functional/API/ZeroBounceTest.php
@@ -1,11 +1,21 @@
 <?php
 
+/**
+ * The tests for ZeroBounce::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Functional\API
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Functional\API;
 
 use Dotenv\Dotenv;
 use Knack\ZeroBounce\API\ZeroBounce;
 use Knack\ZeroBounce\Enums\StatusEnum;
-use Knack\ZeroBounce\Exceptions\EmptyAPIKeyException;
 use Knack\ZeroBounce\Exceptions\ResponseException;
 use Knack\ZeroBounce\Exceptions\ZeroBounceException;
 use Knack\ZeroBounce\Utilities\Environment;
@@ -17,7 +27,7 @@ use Throwable;
  * Class ZeroBounceTest
  *
  * @category Tests
- * @package  Knack\ZeroBounce\Tests
+ * @package  Knack\ZeroBounce\Tests\Functional\API
  * @author   Doug Woodrow <doug@joinknack.com>
  * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
  * @link     https://joinknack.com
@@ -42,6 +52,8 @@ final class ZeroBounceTest extends TestCase
 
     /**
      * Test Graceful API Key handling.
+     *
+     * @return void
      */
     public function testGracefulAPIKeyHandling(): void
     {
@@ -70,7 +82,8 @@ final class ZeroBounceTest extends TestCase
      *
      * @return void
      */
-    public function testFailedAPICall(): void {
+    public function testFailedAPICall(): void
+    {
         $this->expectException(ResponseException::class);
 
         $mocked = Mockery::mock(ZeroBounce::class);

--- a/tests/functional/Providers/ZeroBounceServiceProviderTest.php
+++ b/tests/functional/Providers/ZeroBounceServiceProviderTest.php
@@ -1,14 +1,27 @@
 <?php
 
-use Knack\ZeroBounce\API\ZeroBounce;
+/**
+ * The tests for ZeroBounceServiceProvider::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Functional\Providers
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
+namespace Knack\ZeroBounce\Tests\Functional\Providers;
+
 use Knack\ZeroBounce\Providers\ZeroBounceServiceProvider;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Class ZeroBounceServiceProviderTest
  *
  * @category Tests
- * @package  Knack\ZeroBounce\Tests
+ * @package  Knack\ZeroBounce\Tests\Functional\Providers
  * @author   Doug Woodrow <doug@joinknack.com>
  * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
  * @link     https://joinknack.com

--- a/tests/functional/Utilities/EnvironmentTest.php
+++ b/tests/functional/Utilities/EnvironmentTest.php
@@ -1,14 +1,37 @@
 <?php
+
+/**
+ * The tests for Environment::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Functional\Utilities
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Functional\Utilities;
 
 use Dotenv\Dotenv;
 use Knack\ZeroBounce\Utilities\Environment;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class EnvironmentTest
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Functional\Utilities
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 final class EnvironmentTest extends TestCase
 {
     /**
      * Test set up.
+     *
+     * @return void
      */
     public function setUp(): void
     {
@@ -19,9 +42,24 @@ final class EnvironmentTest extends TestCase
 
     /**
      * Test Environment Variable is fetched successfully.
+     *
+     * @return void
      */
     public function testEnvironmentVariableFetch(): void
     {
         $this->assertNotNull(Environment::get('ZEROBOUNCE_API_KEY'));
+    }
+
+    /**
+     * Test Environment Variable uses default variable if no value is found for the specified key.
+     *
+     * @return void
+     */
+    public function testEnvironmentVariableDefault(): void
+    {
+        $this->assertIsBool(Environment::get('NONEXISTENT_KEY', true));
+        $this->assertIsString(Environment::get('NONEXISTENT_KEY', 'testing'));
+        $this->assertIsFloat(Environment::get('NONEXISTENT_KEY', 1.0));
+        $this->assertIsInt(Environment::get('NONEXISTENT_KEY', 1));
     }
 }

--- a/tests/unit/Enum/GenderEnumTest.php
+++ b/tests/unit/Enum/GenderEnumTest.php
@@ -1,4 +1,16 @@
 <?php
+
+/**
+ * The tests for GenderEnum::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Enum
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Enums\GenderEnum;
@@ -8,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * Class GenderEnumTest
  *
  * @category Tests
- * @package  Knack\ZeroBounce\Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Enum
  * @author   Doug Woodrow <doug@joinknack.com>
  * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
  * @link     https://joinknack.com

--- a/tests/unit/Enum/StatusEnumTest.php
+++ b/tests/unit/Enum/StatusEnumTest.php
@@ -1,4 +1,16 @@
 <?php
+
+/**
+ * The tests for StatusEnum::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Enum
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Enums\StatusEnum;
@@ -8,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * Class StatusEnumTest
  *
  * @category Tests
- * @package  Knack\ZeroBounce\Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Enum
  * @author   Doug Woodrow <doug@joinknack.com>
  * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
  * @link     https://joinknack.com
@@ -17,6 +29,8 @@ final class StatusEnumTest extends TestCase
 {
     /**
      * Test Enum non-null value is returned when non-null value is passed.
+     *
+     * @return void
      */
     public function testOnNonNullValue(): void
     {
@@ -25,6 +39,8 @@ final class StatusEnumTest extends TestCase
 
     /**
      * Test Enum null value is returned when null value is passed.
+     *
+     * @return void
      */
     public function testOnNullValue(): void
     {
@@ -36,7 +52,7 @@ final class StatusEnumTest extends TestCase
      *
      * @return void
      */
-    public function testCorrectValuesReturned()
+    public function testCorrectValuesReturned(): void
     {
         $this->assertEquals(StatusEnum::VALID, StatusEnum::from(StatusEnum::VALID));
         $this->assertEquals(StatusEnum::INVALID, StatusEnum::from(StatusEnum::INVALID));

--- a/tests/unit/Enum/SubStatusEnumTest.php
+++ b/tests/unit/Enum/SubStatusEnumTest.php
@@ -1,4 +1,16 @@
 <?php
+
+/**
+ * The tests for SubStatusEnum::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Enum
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Enums\SubStatusEnum;
@@ -8,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * Class SubStatusEnumTest
  *
  * @category Tests
- * @package  Knack\ZeroBounce\Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Enum
  * @author   Doug Woodrow <doug@joinknack.com>
  * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
  * @link     https://joinknack.com
@@ -17,16 +29,20 @@ final class SubStatusEnumTest extends TestCase
 {
     /**
      * Test Enum non-null value is returned when non-null value is passed.
+     *
+     * @return void
      */
-    public function testOnNonNullValue()
+    public function testOnNonNullValue(): void
     {
         $this->assertNotNull(SubStatusEnum::from(SubStatusEnum::ANTISPAM_SYSTEM));
     }
 
     /**
      * Test Enum null value is returned when null value is passed.
+     *
+     * @return void
      */
-    public function testOnNullValue()
+    public function testOnNullValue(): void
     {
         $this->assertNull(SubStatusEnum::from(null));
     }
@@ -36,7 +52,7 @@ final class SubStatusEnumTest extends TestCase
      *
      * @return void
      */
-    public function testCorrectValuesReturned()
+    public function testCorrectValuesReturned(): void
     {
         $this->assertEquals(SubStatusEnum::ANTISPAM_SYSTEM, SubStatusEnum::from(SubStatusEnum::ANTISPAM_SYSTEM));
         $this->assertEquals(SubStatusEnum::GREYLISTED, SubStatusEnum::from(SubStatusEnum::GREYLISTED));

--- a/tests/unit/Exceptions/EmptyAPIKeyExceptionTest.php
+++ b/tests/unit/Exceptions/EmptyAPIKeyExceptionTest.php
@@ -1,13 +1,36 @@
 <?php
-namespace Knack\ZeroBounce\Tests\Unit\Enum;
+
+/**
+ * The tests for EmptyAPIKeyException::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
+namespace Knack\ZeroBounce\Tests\Unit\Exceptions;
 
 use Knack\ZeroBounce\Exceptions\EmptyAPIKeyException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class EmptyAPIKeyExceptionTest
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 final class EmptyAPIKeyExceptionTest extends TestCase
 {
     /**
      * Test an Exception is created successfully.
+     *
+     * @return void
      */
     public function testExceptionCreated(): void
     {

--- a/tests/unit/Exceptions/ResponseExceptionTest.php
+++ b/tests/unit/Exceptions/ResponseExceptionTest.php
@@ -1,13 +1,36 @@
 <?php
+
+/**
+ * The tests for ResponseException::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Exceptions\ResponseException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class ResponseExceptionTest
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 final class ResponseExceptionTest extends TestCase
 {
     /**
      * Test an Exception is created successfully.
+     *
+     * @return void
      */
     public function testExceptionCreated(): void
     {

--- a/tests/unit/Exceptions/ZeroBounceExceptionTest.php
+++ b/tests/unit/Exceptions/ZeroBounceExceptionTest.php
@@ -1,13 +1,36 @@
 <?php
+
+/**
+ * The tests for ZeroBounceException::class
+ *
+ * PHP Version 7.0
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 namespace Knack\ZeroBounce\Tests\Unit\Enum;
 
 use Knack\ZeroBounce\Exceptions\ZeroBounceException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class ZeroBounceExceptionTest
+ *
+ * @category Tests
+ * @package  Knack\ZeroBounce\Tests\Unit\Exceptions
+ * @author   Doug Woodrow <doug@joinknack.com>
+ * @license  https://github.com/KnackTech/zerobounce/blob/develop/LICENSE MIT License
+ * @link     https://joinknack.com
+ */
 final class ZeroBounceExceptionTest extends TestCase
 {
     /**
      * Test an Exception is created successfully.
+     *
+     * @return void
      */
     public function testExceptionCreated(): void
     {


### PR DESCRIPTION
# Description

Please include a summary of the changes as well as the motivation/context for reviewers.

`Environment::get()` now supports returning default values from the second passed argument. The internals of how `Environment` does this have also been updated, using code similar to Laravel's `env` function. 

Also, some missing formatting changes that were needed have also been updated.

# Issues

Please include the issues that this PR will affect or close.

- Closes #29 

# Checklist

Please ensure that all of the items are checked before your PR is merged.

- [x] I have performed a self-review of my own code (e.g. no typos, unnecessary comments, unused vars, etc)
- [x] I have added/updated tests that prove my fix is effective or that my feature works
